### PR TITLE
feat(config): externalize RPC URLs via environment variables

### DIFF
--- a/packages/contracts/deploy-helpers/index.ts
+++ b/packages/contracts/deploy-helpers/index.ts
@@ -18,7 +18,7 @@ export const createExecuteWithLog = (execute: DeploymentsExtension["execute"]) =
 export const isOwnershipRenounced = async (contractAddress: any) => {
   try {
     // Set up provider and wallet
-    const provider = new ethers.JsonRpcProvider("https://rpc.regtest.midl.xyz");
+    const provider = new ethers.JsonRpcProvider(process.env.EVM_RPC || "https://rpc.regtest.midl.xyz");
 
     // Connect to contract
     const contract = new ethers.Contract(
@@ -42,7 +42,7 @@ export const isOwnershipRenounced = async (contractAddress: any) => {
 export const lqtyTokenCheck = async (contractAddress: any) => {
   try {
     // Set up provider and wallet
-    const provider = new ethers.JsonRpcProvider("https://rpc.regtst.midl.xyz");
+    const provider = new ethers.JsonRpcProvider(process.env.EVM_RPC || "https://rpc.regtest.midl.xyz");
 
     // Connect to contract
     const contract = new ethers.Contract(

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -85,27 +85,25 @@ const config: HardhatUserConfig = {
         btcConfirmationsRequired: 1,
         hardhatNetwork: "default",
         network: {
-          explorerUrl: "https://mempool.regtest.midl.xyz",
+          explorerUrl: process.env.MEMPOOL_RPC || "https://mempool.regtest.midl.xyz",
           id: "regtest",
           network: "regtest"
         },
         provider: new MempoolSpaceProvider({
-          "regtest": "https://mempool.regtest.midl.xyz",
+          regtest: process.env.MEMPOOL_RPC || "https://mempool.regtest.midl.xyz"
         } as any)
-      },
+      }
     }
-
   },
   networks: {
     default: {
-      url: "https://rpc.regtest.midl.xyz",
-      chainId: 777,
-
+      url: process.env.EVM_RPC || "https://rpc.regtest.midl.xyz",
+      chainId: 777
     },
-      pkRemote: {
-      url: "https://rpc.regtest.midl.xyz",
-      chainId: 777,
-    },
+    pkRemote: {
+      url: process.env.EVM_RPC || "https://rpc.regtest.midl.xyz",
+      chainId: 777
+    }
   },
 
   mocha: { timeout: 12000000 },

--- a/packages/dev-frontend/.env.example
+++ b/packages/dev-frontend/.env.example
@@ -1,0 +1,4 @@
+VITE_APP_VERSION=a50453b2dc9d6a22beb438e6d8859a2ac1c3bb9b
+VITE_APP_MAINTENANCE=false
+EVM_RPC=https://rpc.regtest.midl.xyz
+MEMPOOL_RPC=https://mempool.regtest.midl.xyz

--- a/packages/dev-frontend/src/App.tsx
+++ b/packages/dev-frontend/src/App.tsx
@@ -12,7 +12,6 @@ import { getConfig } from "./config";
 import { LiquityProvider } from "./hooks/LiquityContext";
 import theme from "./theme";
 
-import { AddressPurpose } from "@midl-xyz/midl-js-core";
 import { midlRegtest } from "@midl-xyz/midl-js-executor";
 import { AppLoader } from "./components/AppLoader";
 import { DisposableWalletProvider } from "./testUtils/DisposableWalletProvider";
@@ -84,6 +83,7 @@ const loader = <AppLoader />;
 
 const App = () => {
   const queryClient = useMemo(() => new QueryClient(), []);
+
   const wagmiConfig = useMemo(() => {
     return createConfig({
       chains: [
@@ -91,13 +91,13 @@ const App = () => {
           ...midlRegtest,
           rpcUrls: {
             default: {
-              http: [midlRegtest.rpcUrls.default.http[0]]
+              http: [import.meta.env.VITE_EVM_RPC]
             }
           }
         } as Chain
       ],
       transports: {
-        [midlRegtest.id]: http(midlRegtest.rpcUrls.default.http[0])
+        [midlRegtest.id]: http(import.meta.env.VITE_EVM_RPC)
       }
     });
   }, []);
@@ -108,16 +108,16 @@ const App = () => {
         <QueryClientProvider client={queryClient}>
           <WagmiMidlProvider
             chain={{
-            ...midlRegtest,
+              ...midlRegtest,
 
-            rpcUrls: {
-              default: {
-                http: ['https://rpc.regtest.midl.xyz'],
-              },
-            },
-          }}
-        >
-          <WalletConnector loader={loader}>
+              rpcUrls: {
+                default: {
+                  http: [import.meta.env.VITE_EVM_RPC]
+                }
+              }
+            }}
+          >
+            <WalletConnector loader={loader}>
               <LiquityProvider
                 loader={loader}
                 unsupportedNetworkFallback={<UnsupportedNetworkFallback />}
@@ -127,11 +127,11 @@ const App = () => {
                   <LiquityFrontend loader={loader} />
                 </TransactionProvider>
               </LiquityProvider>
-              </WalletConnector>
-            </WagmiMidlProvider>
+            </WalletConnector>
+          </WagmiMidlProvider>
         </QueryClientProvider>
       </MidlProvider>
-    </ThemeUIProvider> 
+    </ThemeUIProvider>
   );
 };
 

--- a/packages/dev-frontend/src/config/midlConfig.ts
+++ b/packages/dev-frontend/src/config/midlConfig.ts
@@ -1,11 +1,11 @@
-import { leatherConnector, xverseConnector } from '@midl-xyz/midl-js-connectors';
-import { createConfig, MempoolSpaceProvider, regtest } from '@midl-xyz/midl-js-core';
+import { leatherConnector, xverseConnector } from "@midl-xyz/midl-js-connectors";
+import { createConfig, MempoolSpaceProvider, regtest } from "@midl-xyz/midl-js-core";
 
 export const midlConfig = createConfig({
   networks: [regtest],
   persist: true,
   provider: new MempoolSpaceProvider({
-    regtest: 'https://mempool.regtest.midl.xyz',
-  } as any), // Any is used coz we don't wanna give mainnet links
-  connectors: [xverseConnector(), leatherConnector()],
+    regtest: import.meta.env.VITE_MEMPOOL_RPC || "https://mempool.regtest.midl.xyz"
+  }), // Any is used coz we don't wanna give mainnet links
+  connectors: [xverseConnector(), leatherConnector()]
 });

--- a/packages/dev-frontend/src/config/midlConfig.ts
+++ b/packages/dev-frontend/src/config/midlConfig.ts
@@ -6,6 +6,6 @@ export const midlConfig = createConfig({
   persist: true,
   provider: new MempoolSpaceProvider({
     regtest: import.meta.env.VITE_MEMPOOL_RPC || "https://mempool.regtest.midl.xyz"
-  }), // Any is used coz we don't wanna give mainnet links
+  } as any), // Any is used coz we don't wanna give mainnet links
   connectors: [xverseConnector(), leatherConnector()]
 });

--- a/packages/dev-frontend/vite.config.ts
+++ b/packages/dev-frontend/vite.config.ts
@@ -7,6 +7,10 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
+  define: {
+    'import.meta.env.VITE_EVM_RPC': JSON.stringify(process.env.EVM_RPC || 'https://rpc.regtest.midl.xyz'),
+    'import.meta.env.VITE_MEMPOOL_RPC': JSON.stringify(process.env.MEMPOOL_RPC || 'https://mempool.regtest.midl.xyz')
+  },
   plugins: [
     react(),
     nodePolyfills({


### PR DESCRIPTION
- Updated provider URLs in `deploy-helpers` to use environment variables
- Replaced hardcoded RPC URLs in frontend configuration with `import.meta.env` values
- Added `.env.example` file with placeholders for environment variables
- Modified Vite config to define environment variables for RPC URLs
- Refactored Hardhat `networks` configuration to use environment variables for flexibility